### PR TITLE
fix: add -p flag to mkdir instead of using logic

### DIFF
--- a/funcs.sh
+++ b/funcs.sh
@@ -54,7 +54,7 @@ cpptempl() {
 
 hidevscc() {
     code -g .vscode/settings.json:4:23
-    [ -d .vscode ] || mkdir .vscode
+    mkdir -p .vscode
     cat >.vscode/settings.json <<-END
 		{
 		    "files.exclude": {


### PR DESCRIPTION
In line 57, the script funcs.sh makes use of
        [ -d .vscode ] || mkdir .vscode
to conditionally create the directory .vscode, however that is not
necessary, as mkdir has the -p flag that does not return an error if
the directory already exists. From the manual:

       -p, --parents
              no error if existing, make parent directories as needed

Signed-off-by: J. Renner <j@lerenner.dev>